### PR TITLE
fix php8.4 warnings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+vendor
+.DS_Store
+.idea
+.vscode

--- a/src/Beautify.php
+++ b/src/Beautify.php
@@ -20,7 +20,7 @@ class Beautify extends BeautifyHTMLAdapted
      * @param Closure|null $jsBeautify
      * @return string
      */
-    public static function html(string $input, array $options = null, Closure $cssBeautify = null, Closure $jsBeautify = null): string
+    public static function html(string $input, ?array $options = null, ?Closure $cssBeautify = null, ?Closure $jsBeautify = null): string
     {
         return Beautify::init($options, $cssBeautify, $jsBeautify)->beautify($input);
     }
@@ -33,7 +33,7 @@ class Beautify extends BeautifyHTMLAdapted
      * @param Closure|null $jsBeautify
      * @return static
      */
-    public static function init(array $options = null, Closure $cssBeautify = null, Closure $jsBeautify = null): static
+    public static function init(?array $options = null, ?Closure $cssBeautify = null, ?Closure $jsBeautify = null): static
     {
         return new static($options, $cssBeautify, $jsBeautify);
     }

--- a/src/BeautifyHTMLAdapted.php
+++ b/src/BeautifyHTMLAdapted.php
@@ -150,7 +150,7 @@ class BeautifyHTMLAdapted
      * @param Closure|null $cssBeautify
      * @param Closure|null $jsBeautify
      */
-    public function __construct(array $options = null, Closure $cssBeautify = null, Closure $jsBeautify = null)
+    public function __construct(?array $options = null, ?Closure $cssBeautify = null, ?Closure $jsBeautify = null)
     {
         // Apply defaults, so that only unrecognized option keys maybe updated.
         $this->options = static::$defaultOptions;
@@ -645,7 +645,7 @@ class BeautifyHTMLAdapted
      * @param bool|null $force
      * @return void
      */
-    private function printNewLine(array &$arr, bool $force = null)
+    private function printNewLine(array &$arr, ?bool $force = null)
     {
         $this->lineCharCount = 0;
         if (!$arr || !count($arr)) {
@@ -731,7 +731,7 @@ class BeautifyHTMLAdapted
      * @param array|null $options
      * @return array|$this
      */
-    protected function options(array $options = null): array|static
+    protected function options(?array $options = null): array|static
     {
         if (is_null($options)) {
             return $this->options;


### PR DESCRIPTION
- **add gitignore**
- **Fix php 8.4 warning: Implicitly marking parameter as nullable is deprecated**
